### PR TITLE
Remove unnecessary "use strict".

### DIFF
--- a/src/recaptcha-wrapper.js
+++ b/src/recaptcha-wrapper.js
@@ -1,4 +1,3 @@
-"use strict";
 import ReCAPTCHA from "./recaptcha";
 import makeAsyncScriptLoader from "react-async-script";
 

--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -1,4 +1,3 @@
-"use strict";
 import React, { PropTypes } from "react";
 
 const ReCAPTCHA = React.createClass({


### PR DESCRIPTION
Today I've done some research for one issue.
In the course of it I've found that `babel` always auto-inserts "use strict".

There is no [source.js](https://github.com/AlexKVal/bug_babel_webpack/blob/master/client.js) "use strict" in the source file.
But here it is present https://github.com/AlexKVal/bug_babel_webpack/blob/master/bundle.js#L47 in output file.

You can use my [simple trash project](https://github.com/AlexKVal/bug_babel_webpack) as a playground
and make sure of it by yourself. :)
