### PR TITLE
Bump babel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "yargs": "~3.7.2"
   },
   "dependencies": {
-    "babel-runtime": "~5.1.11",
+    "babel-runtime": "~5.4.7",
     "react-async-script": "~0.3.1"
   }
 }


### PR DESCRIPTION
Just some housekeeping; bumping version of babel to the most recent one. I think people are generally more likely to use a module if they see up-to-date deps :) thanks for working on this!