### PR TITLE
Fix reliance on diff bypass

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -69,8 +69,12 @@ const ReCAPTCHA = React.createClass({
   componentDidMount() {
     this.explicitRender();
   },
+  
+  shouldComponentUpdate() {
+    return false;
+  },
 
-  componentDidUpdate() {
+  componentWillReceiveProps() {
     this.explicitRender();
   },
 


### PR DESCRIPTION
This component relies on non-react DOM creation, which means it should tell React not to diff its contents.  Currently it's relying on React's perceived element ownership in order to bypass externally created elements during diffing, causing unnecessary work. In Preact, elements are not bypassed and instead get recycled because the diff was not told to ignore the component's contents.  See developit/preact-compat#225 for details.
