### PR TITLE
make dependencies more friendly for consuming packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "homepage": "https://github.com/dozoisch/react-google-recaptcha",
   "peerDependencies": {
-    "react": ">=0.14"
+    "react": ">=0.14",
+    "react-async-script": "~0.5.0"
   },
   "devDependencies": {
     "babel": "~5.8.21",
@@ -62,10 +63,7 @@
     "react": "~0.14.0",
     "react-dom": "~0.14.0",
     "release-script": "^0.5.3",
-    "webpack": "~1.12.2"
-  },
-  "dependencies": {
-    "babel-runtime": "^5.8.0",
-    "react-async-script": "~0.5.0"
+    "webpack": "~1.12.2",
+    "babel-runtime": "^5.8.0"
   }
 }


### PR DESCRIPTION
Don't bring a particular version of babel-runtime as direct dependency.  Can cause package bloat or duplication downstream for consumers.