### PR TITLE
Avoid 'Uncaught Error: removeComponentAsRefFrom'

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -8,6 +8,8 @@ export default class ReCAPTCHA extends React.Component {
     this.handleExpired = this.handleExpired.bind(this);
   }
 
+  captchaEl = null;
+
   getValue() {
     if (this.props.grecaptcha && this.state.widgetId !== undefined) {
       return this.props.grecaptcha.getResponse(this.state.widgetId);
@@ -40,7 +42,7 @@ export default class ReCAPTCHA extends React.Component {
 
   explicitRender(cb) {
     if (this.props.grecaptcha && this.state.widgetId === undefined) {
-      const id = this.props.grecaptcha.render(this.refs.captcha, {
+      const id = this.props.grecaptcha.render(this.captchaEl, {
         sitekey: this.props.sitekey,
         callback: this.props.onChange,
         theme: this.props.theme,
@@ -71,7 +73,7 @@ export default class ReCAPTCHA extends React.Component {
     const { sitekey, onChange, theme, type, tabindex, onExpired, size, stoken, grecaptcha, badge, ...childProps } = this.props;
     /* eslint-enable no-unused-vars */
     return (
-      <div {...childProps} ref="captcha" />
+      <div {...childProps} ref={(el) => { this.captchaEl = el; }} />
     );
   }
 }


### PR DESCRIPTION
Hello,

I faced this error when using with React 15.5.4, however, I couldn't reproduce it. I managed to fix by using ref={function} instead of ref="string"

> Uncaught Error: removeComponentAsRefFrom(...): Only a ReactOwner can have refs. You might be removing a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded

Hopefully it get merged

Thank you!