### PR TITLE
Fix race on execute()

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -22,6 +22,8 @@ export default class ReCAPTCHA extends React.Component {
 
     if (grecaptcha && widgetId !== undefined) {
       return grecaptcha.execute(widgetId);
+    } else {
+      this._executeRequested = true;
     }
   }
 
@@ -55,6 +57,10 @@ export default class ReCAPTCHA extends React.Component {
       this.setState({
         widgetId: id,
       }, cb);
+    }
+    if (this._executeRequested && this.props.grecaptcha && this.state.widgetId !== undefined) {
+      this._executeRequested = false;
+      this.execute();
     }
   }
 


### PR DESCRIPTION
Previously, if the call to execute() happened before
the script is asynchnonously loaded and fully rendered,
the Captcha would never execute.