### PR TITLE
Add es2015 module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,19 @@
 {
-  "presets": [
-    "react",
-    [ "es2015", { "loose": true } ]
-  ],
-  "plugins": [ "transform-runtime", "transform-object-rest-spread" ]
+
+  "env": {
+    "development": {
+      "presets": [
+        "react",
+        [ "es2015", { "loose": true } ]
+      ],
+      "plugins": [ "transform-runtime", "transform-object-rest-spread" ]
+    },
+    "es": {
+      "presets": [
+        "react",
+        [ "es2015", { "loose": true, "modules": false } ]
+      ],
+      "plugins": [ "transform-runtime", "transform-object-rest-spread" ],
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.9.7",
   "description": "React Component Wrapper for Google reCAPTCHA",
   "main": "lib/recaptcha-wrapper.js",
+  "module": "lib/es/recaptcha-wrapper.js",
   "directories": {
     "lib": "lib/"
   },
   "scripts": {
-    "build": "rm -rf lib && babel src --out-dir lib",
+    "build": "rm -rf lib && npm run build:cjs && npm run build:es",
+    "build:cjs": "babel src --out-dir lib",
+    "build:es": "BABEL_ENV=es babel src --out-dir lib/es",
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
     "test": "karma start --single-run",


### PR DESCRIPTION
This adds build with no module transform on babel.

It enables webpack 3 to do scope hoisting.