### PR TITLE
Fix context issue with handleExpired()

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -56,7 +56,7 @@ export default class ReCAPTCHA extends React.Component {
         theme: this.props.theme,
         type: this.props.type,
         tabindex: this.props.tabindex,
-        "expired-callback": this.handleExpired,
+        "expired-callback": this.handleExpired.bind(this),
         size: this.props.size,
         stoken: this.props.stoken,
         badge: this.props.badge,


### PR DESCRIPTION
When `handleExpired` is called it doesn't have the correct context and thus `this.props` is undefined and an exception is thrown in the browser. Prior to this fix if I fill out/solve the captcha and let the browser sit for a few minutes the exception is thrown. After applying this fix the issue is resolved. However I'm not sure an easy way to add a test for this and noticed there are empty placeholders in place for expiring, so my guess is others found it difficult as well.