### PR TITLE
Fix: Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Component wrapper for [Google reCAPTCHA v2][reCAPTCHA]
 ## Installation
 
 ```shell
-npm install --save react-google-recaptcha react-async-script
+npm install --save react-google-recaptcha
 ```
 
 ### React < 15.5

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   },
   "homepage": "https://github.com/dozoisch/react-google-recaptcha",
   "peerDependencies": {
-    "react": ">=15.5.0",
-    "react-async-script": ">=0.9.1"
+    "react": ">=15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",
@@ -75,6 +74,7 @@
     "webpack": "~1.14.0"
   },
   "dependencies": {
-    "prop-types": ">=15.5.0"
+    "prop-types": ">=15.5.0",
+    "react-async-script": ">=0.9.1"
   }
 }


### PR DESCRIPTION
**Description:**
Move `react-async-script` from `peerDependencies` to `dependencies` so that it will be installed along with the `react-google-recaptcha` package