### PR TITLE
Make the onChange prop not required

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -118,7 +118,7 @@ export default class ReCAPTCHA extends React.Component {
 ReCAPTCHA.displayName = "ReCAPTCHA";
 ReCAPTCHA.propTypes = {
   sitekey: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
   grecaptcha: PropTypes.object,
   theme: PropTypes.oneOf(["dark", "light"]),
   type: PropTypes.oneOf(["image", "audio"]),
@@ -130,6 +130,7 @@ ReCAPTCHA.propTypes = {
   badge: PropTypes.oneOf(["bottomright", "bottomleft", "inline"]),
 };
 ReCAPTCHA.defaultProps = {
+  onChange: () => {},
   theme: "light",
   type: "image",
   tabindex: 0,


### PR DESCRIPTION
Resolves #99 

The component works fine when no `onChange` handler is provided, because an input is present with the current value. Because of that, submitting a form that this is used in will have the correct param.

I decided to accomplish this by providing a default value of `() => {}`. That way, existing code can call the callback, and things will still "work", even if no callback was provided.