### PR TITLE
adding-lang-to-recaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Properties used to customise the rendering:
 | onExpired | func | *optional* callback when the challenge is expired and has to be redone by user. By default it will call the onChange with null to signify expired callback. |
 | onErrored | func | *optional* callback when the challenge errored, most likely due to network issues. |
 | stoken | string | *optional* set the stoken parameter, which allows the captcha to be used from different domains, see [reCAPTCHA secure-token] |
+| hl | string | *optional* set the hl parameter, which allows the captcha to be used from different languages, see [reCAPTCHA hl] |
 | size | enum | *optional* `compact`, `normal` or `invisible`. This allows you to change the size or do an invisible captcha |
-| badge | enum | *optional* `bottomright`, `bottomleft` or `inline`. Positions reCAPTCHA badge. *Only for invisible reCAPTCHA* |
+| badge | enum | *optional* `bottomright`, `bottomleft` or `inline`. Positions reCAPTCHA badge. *Only for invisible reCAPTCHA* |1
 
 ### Component Instance API
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Properties used to customise the rendering:
 | stoken | string | *optional* set the stoken parameter, which allows the captcha to be used from different domains, see [reCAPTCHA secure-token] |
 | hl | string | *optional* set the hl parameter, which allows the captcha to be used from different languages, see [reCAPTCHA hl] |
 | size | enum | *optional* `compact`, `normal` or `invisible`. This allows you to change the size or do an invisible captcha |
-| badge | enum | *optional* `bottomright`, `bottomleft` or `inline`. Positions reCAPTCHA badge. *Only for invisible reCAPTCHA* |1
+| badge | enum | *optional* `bottomright`, `bottomleft` or `inline`. Positions reCAPTCHA badge. *Only for invisible reCAPTCHA* |
 
 ### Component Instance API
 

--- a/README.md
+++ b/README.md
@@ -171,3 +171,4 @@ Pre `1.0.0` and `React < 16.4.1` support details in [0.14.0](https://github.com/
 [js_api]: https://developers.google.com/recaptcha/docs/display#js_api
 [rb]: https://github.com/react-bootstrap/react-bootstrap/
 [reCAPTCHA secure-token]: https://developers.google.com/recaptcha/docs/secure_token
+[reCAPTCHA hl]: https://developers.google.com/recaptcha/docs/language

--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -64,6 +64,7 @@ export default class ReCAPTCHA extends React.Component {
         "error-callback": this.handleErrored,
         size: this.props.size,
         stoken: this.props.stoken,
+        hl: this.props.hl,
         badge: this.props.badge,
       });
       this.captcha.appendChild(wrapper);
@@ -124,6 +125,7 @@ export default class ReCAPTCHA extends React.Component {
       stoken,
       grecaptcha,
       badge,
+      hl,
       ...childProps
     } = this.props;
     /* eslint-enable no-unused-vars */
@@ -143,6 +145,7 @@ ReCAPTCHA.propTypes = {
   onErrored: PropTypes.func,
   size: PropTypes.oneOf(["compact", "normal", "invisible"]),
   stoken: PropTypes.string,
+  hl: PropTypes.string,
   badge: PropTypes.oneOf(["bottomright", "bottomleft", "inline"]),
 };
 ReCAPTCHA.defaultProps = {
@@ -152,4 +155,5 @@ ReCAPTCHA.defaultProps = {
   tabindex: 0,
   size: "normal",
   badge: "bottomright",
+  hl: "en",
 };


### PR DESCRIPTION
I was unable to use 'lang' prop to override the language.
it is just much simpler to let user send the lang attribute to the component using the `hl` attribute. and default to en. 

makes everyone's live easier :D 
![Screen Shot 2019-07-10 at 5 16 10 PM](https://user-images.githubusercontent.com/2381423/61013182-7fd90000-a336-11e9-9f08-6336cccb78ab.png)
![Screen Shot 2019-07-10 at 5 15 01 PM](https://user-images.githubusercontent.com/2381423/61013183-7fd90000-a336-11e9-8418-0260138b10f1.png)

