### PR TITLE
Made import of React.Component more specific

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -1,7 +1,7 @@
-import React from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 
-export default class ReCAPTCHA extends React.Component {
+export default class ReCAPTCHA extends Component {
   constructor() {
     super();
     this.handleExpired = this.handleExpired.bind(this);

--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 export default class ReCAPTCHA extends Component {


### PR DESCRIPTION
Fixes issue #158 when using Preact.js V10+ which now has no `export default` for `Preact` and won't by default include Preact.Component in the import.
dozoisch/react-google-recaptcha#158