### PR TITLE
Updated Prettier to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6434,9 +6434,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.1",
-    "prettier": "1.19.1",
+    "prettier": "^2.1.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/test/recaptcha.spec.js
+++ b/test/recaptcha.spec.js
@@ -22,7 +22,7 @@ describe("ReCAPTCHA", () => {
   });
 
   it("should call grecaptcha.render, when it is already loaded", () => {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       const grecaptchaMock = {
         render(node, options) {
           expect(node).toBeTruthy();
@@ -155,7 +155,7 @@ describe("ReCAPTCHA", () => {
     const instance = ReactTestUtils.renderIntoDocument(React.createElement(WrappingComponent));
     const executeAsyncDirectValue = instance._internalRef.current.executeAsync();
     expect(executeAsyncDirectValue).toBeInstanceOf(Promise);
-    return executeAsyncDirectValue.then(executeAsyncResolveValue => {
+    return executeAsyncDirectValue.then((executeAsyncResolveValue) => {
       expect(executeAsyncResolveValue).toBe(TOKEN);
     });
   });


### PR DESCRIPTION
Only impact seems to be from https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-arrowparens-to-always-7430httpsgithubcomprettierprettierpull7430-by-kachkaevhttpsgithubcomkachkaev

I can make it so it is like before if you prefer, but having used the same change in another project for a few months, it grew on me and makes it easier for a lot of use cases. (see https://twitter.com/ManuelBieh/status/1181880524954050560)