### PR TITLE
Remove timeout removal, remove component unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v3.0.0-alpha.1 - Mon 23 Nov 2020 22:25 ET
+---------------------------------------
+- Add isolated prop [(#179)](https://github.com/dozoisch/react-google-recaptcha/issues/179)
+- Update dependencies 1 [(#187)](https://github.com/dozoisch/react-google-recaptcha/issues/187)
+- Update dependencies 2 [(#194)](https://github.com/dozoisch/react-google-recaptcha/issues/194)
+- Remove Timeout Removal [(#196)](https://github.com/dozoisch/react-google-recaptcha/issues/196)
+
+
+
 v2.1.0 - Fri 5 Jun 2020 22:05 PST
 ---------------------------------------
 - Add promise based Execution [(#163)](https://github.com/dozoisch/react-google-recaptcha/issues/163)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-recaptcha",
-  "version": "2.1.0",
+  "version": "3.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-recaptcha",
-  "version": "2.1.0",
+  "version": "3.0.0-alpha.1",
   "description": "React Component Wrapper for Google reCAPTCHA",
   "main": "lib/index.js",
   "module": "lib/esm/index.js",

--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -48,6 +48,12 @@ export default class ReCAPTCHA extends React.Component {
     }
   }
 
+  forceReset() {
+    if (this.props.grecaptcha) {
+      this.props.grecaptcha.reset();
+    }
+  }
+
   handleExpired() {
     if (this.props.onExpired) {
       this.props.onExpired();
@@ -109,29 +115,6 @@ export default class ReCAPTCHA extends React.Component {
 
   componentDidUpdate() {
     this.explicitRender();
-  }
-
-  componentWillUnmount() {
-    if (this._widgetId !== undefined) {
-      this.delayOfCaptchaIframeRemoving();
-      this.reset();
-    }
-  }
-
-  delayOfCaptchaIframeRemoving() {
-    const temporaryNode = document.createElement("div");
-    document.body.appendChild(temporaryNode);
-    temporaryNode.style.display = "none";
-
-    // move of the recaptcha to a temporary node
-    while (this.captcha.firstChild) {
-      temporaryNode.appendChild(this.captcha.firstChild);
-    }
-
-    // delete the temporary node after reset will be done
-    setTimeout(() => {
-      document.body.removeChild(temporaryNode);
-    }, 5000);
   }
 
   handleRecaptchaRef(elem) {


### PR DESCRIPTION
Attempt to fix #171.

Additionally:
- remove the `reset()` call on unmount as it may be the root cause of #103.
- The `reset()` may also not have been necessary
  - Issue #55 was specific to a react error using the same `ref`
  - The fix for #55 with #73 included making a new `div` for each `explicitRender` which is probably all that is sufficient for the fix
- add a new `forceReset` method that calls `grecaptcha.reset()` without needing a `widgetId`
  - this could be used if users experience errors related to #55 again 🤷 

@dozoisch could you possibly publish an alpha/beta of this that I can test? 

📓 If this does all work and simplifies things it will possibly require a major? 🤔 