### PR TITLE
Drop support for react below v17

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "@babel/react",
+    [ "@babel/react", { "runtime": "automatic" } ],
     [ "@babel/env", { "loose": true } ]
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/dozoisch/react-google-recaptcha",
   "peerDependencies": {
-    "react": ">=16.4.1"
+    "react": ">=17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",


### PR DESCRIPTION
As there is a new major version alpha in master.

This PR:
- drops react 16 from peer dependencies
- make babel use the new [automatic jsx transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
