### PR TITLE
Rewrite tests with @testing-library/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,10 +1794,93 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
     "@types/babel__core": {
@@ -2018,6 +2101,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
     },
     "array-includes": {
       "version": "3.1.4",
@@ -2573,6 +2662,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2896,25 +2991,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.26.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
-      "integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.27.0.tgz",
+      "integrity": "sha512-0Ut+CkzpppgFtoIhdzi2LpdpxxBvgFf99eFqWxJnUrO7mMe0eOiNpou6rvNYeVVV6lWZvTah0BFne7k5xHjARg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "estraverse": "^5.2.0",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.hasown": "^1.0.0",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.5"
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "doctrine": {
@@ -2925,12 +3020,6 @@
           "requires": {
             "esutils": "^2.0.2"
           }
-        },
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
         },
         "resolve": {
           "version": "2.0.0-next.3",
@@ -5158,6 +5247,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/core": "^7.15.8",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
+    "@testing-library/react": "^12.1.2",
     "cross-env": "^7.0.3",
     "eslint": "^8.1.0",
     "eslint-config-prettier": "^8.3.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,7 +6,6 @@
   "rules": {
     "no-script-url": 1,
     "no-unused-expressions": 0,
-    "react/no-multi-comp": 0,
-    "react/no-find-dom-node": 1
+    "react/no-multi-comp": 0
   }
 }

--- a/test/recaptcha-wrapper.spec.js
+++ b/test/recaptcha-wrapper.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactTestUtils from "react-dom/test-utils";
+import { render } from "@testing-library/react";
 import ReCAPTCHA from "../src/recaptcha-wrapper";
 
 const VALUE = "some value";
@@ -30,9 +30,8 @@ describe("ReCAPTCHAWrapper", () => {
   });
   it("should proxy functions", () => {
     const ReCaptchaRef = React.createRef();
-    ReactTestUtils.renderIntoDocument(
-      <ReCAPTCHA sitekey="xxx" ref={ReCaptchaRef} onChange={jest.fn()} />,
-    );
+
+    render(<ReCAPTCHA sitekey="xxx" ref={ReCaptchaRef} onChange={jest.fn()} />);
     expect(ReCaptchaRef.current.getValue()).toBe(VALUE);
   });
 });

--- a/test/recaptcha.spec.js
+++ b/test/recaptcha.spec.js
@@ -1,14 +1,12 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import ReactTestUtils from "react-dom/test-utils";
+import { render } from "@testing-library/react";
+
 import ReCAPTCHA from "../src/recaptcha"; // eslint-disable-line no-unused-vars
 
 describe("ReCAPTCHA", () => {
   it("Rendered Component should be a div", () => {
-    const instance = ReactTestUtils.renderIntoDocument(
-      <ReCAPTCHA sitekey="xxx" onChange={jest.fn()} />,
-    );
-    expect(ReactDOM.findDOMNode(instance).nodeName).toBe("DIV");
+    const { container } = render(<ReCAPTCHA sitekey="xxx" onChange={jest.fn()} />);
+    expect(container.firstChild.nodeName).toBe("DIV");
   });
   it("Rendered Component should contained passed props", () => {
     const props = {
@@ -16,9 +14,9 @@ describe("ReCAPTCHA", () => {
       id: "superdefinedId",
       onChange: jest.fn(),
     };
-    const instance = ReactTestUtils.renderIntoDocument(<ReCAPTCHA sitekey="xxx" {...props} />);
-    expect(ReactDOM.findDOMNode(instance).id).toBe(props.id);
-    expect(ReactDOM.findDOMNode(instance).className).toBe(props.className);
+    const { container } = render(<ReCAPTCHA sitekey="xxx" {...props} />);
+    expect(container.firstChild.id).toBe(props.id);
+    expect(container.firstChild.className).toBe(props.className);
   });
 
   it("should call grecaptcha.render, when it is already loaded", () => {
@@ -30,10 +28,7 @@ describe("ReCAPTCHA", () => {
           resolve();
         },
       };
-      const instance = ReactTestUtils.renderIntoDocument(
-        <ReCAPTCHA sitekey="xxx" grecaptcha={grecaptchaMock} onChange={jest.fn()} />,
-      );
-      expect(instance).toBeTruthy();
+      render(<ReCAPTCHA sitekey="xxx" grecaptcha={grecaptchaMock} onChange={jest.fn()} />);
     });
   });
   it("reset, should call grecaptcha.reset with the widget id", () => {
@@ -45,7 +40,7 @@ describe("ReCAPTCHA", () => {
       reset: jest.fn(),
     };
     const ReCaptchaRef = React.createRef();
-    ReactTestUtils.renderIntoDocument(
+    render(
       <ReCAPTCHA
         sitekey="xxx"
         grecaptcha={grecaptchaMock}
@@ -84,8 +79,9 @@ describe("ReCAPTCHA", () => {
         );
       }
     }
-    const instance = ReactTestUtils.renderIntoDocument(React.createElement(WrappingComponent));
-    instance._internalRef.current.execute();
+    const wrappingRef = React.createRef();
+    render(<WrappingComponent ref={wrappingRef} />);
+    wrappingRef.current._internalRef.current.execute();
     expect(grecaptchaMock.execute).toBeCalledWith(WIDGET_ID);
   });
   it("executeAsync, should call grecaptcha.execute with the widget id", () => {
@@ -116,8 +112,9 @@ describe("ReCAPTCHA", () => {
         );
       }
     }
-    const instance = ReactTestUtils.renderIntoDocument(React.createElement(WrappingComponent));
-    instance._internalRef.current.executeAsync();
+    const wrappingRef = React.createRef();
+    render(<WrappingComponent ref={wrappingRef} />);
+    wrappingRef.current._internalRef.current.executeAsync();
     expect(grecaptchaMock.execute).toBeCalledWith(WIDGET_ID);
   });
   it("executeAsync, should return a promise that resolves with the token", () => {
@@ -152,8 +149,10 @@ describe("ReCAPTCHA", () => {
         );
       }
     }
-    const instance = ReactTestUtils.renderIntoDocument(React.createElement(WrappingComponent));
-    const executeAsyncDirectValue = instance._internalRef.current.executeAsync();
+
+    const wrappingRef = React.createRef();
+    render(<WrappingComponent ref={wrappingRef} />);
+    const executeAsyncDirectValue = wrappingRef.current._internalRef.current.executeAsync();
     expect(executeAsyncDirectValue).toBeInstanceOf(Promise);
     return executeAsyncDirectValue.then((executeAsyncResolveValue) => {
       expect(executeAsyncResolveValue).toBe(TOKEN);
@@ -169,7 +168,7 @@ describe("ReCAPTCHA", () => {
         },
       };
       const ReCaptchaRef = React.createRef();
-      ReactTestUtils.renderIntoDocument(
+      render(
         <ReCAPTCHA
           sitekey="xxx"
           grecaptcha={grecaptchaMock}
@@ -190,7 +189,7 @@ describe("ReCAPTCHA", () => {
         },
       };
       const ReCaptchaRef = React.createRef();
-      ReactTestUtils.renderIntoDocument(
+      render(
         <ReCAPTCHA
           sitekey="xxx"
           grecaptcha={grecaptchaMock}
@@ -214,7 +213,7 @@ describe("ReCAPTCHA", () => {
         },
       };
       const ReCaptchaRef = React.createRef();
-      ReactTestUtils.renderIntoDocument(
+      render(
         <ReCAPTCHA
           sitekey="xxx"
           grecaptcha={grecaptchaMock}


### PR DESCRIPTION
This PR changes the tests to use @testing-library/react in preparation for react v18.

I tried to run the old tests against react@18-beta, but there seems to be no easy way with the react/test-utils.

With @testing-library/react@13-alpha and react@18-beta these rewritten tests pass.