### PR TITLE
Trusted Types support as an option in component

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,18 @@ window.recaptchaOptions = {
 };
 ```
 
-### CSP Nonce support
+#### CSP Nonce support
 ```js
 window.recaptchaOptions = {
   nonce: document.querySelector('meta[name=\'csp-nonce\']').getAttribute('content'),
 };
+```
+
+#### Trusted Types support
+```js
+window.recaptchaOptions = {
+  trustedTypes: true,
+}
 ```
 
 #### ReCaptcha loading google recaptcha script manually

--- a/src/recaptcha-wrapper.js
+++ b/src/recaptcha-wrapper.js
@@ -11,6 +11,12 @@ function getOptions() {
 function getURL() {
   const dynamicOptions = getOptions();
   const hostname = dynamicOptions.useRecaptchaNet ? "recaptcha.net" : "www.google.com";
+  if (self.trustedTypes && self.trustedTypes.createPolicy && dynamicOptions.trustedTypes) {
+    const policy = self.trustedTypes.createPolicy('react-google-recaptcha', {
+      createScriptURL: (_ignored) => `https://${hostname}/recaptcha/api.js?onload=${callbackName}&render=explicit&trustedtypes=true`
+    });
+    return policy.create('_ignored');
+  }
   return `https://${hostname}/recaptcha/api.js?onload=${callbackName}&render=explicit`;
 }
 


### PR DESCRIPTION
Hello!

We (@kj202 and I) noticed that the code in this library will cause [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) violations by loading a version of the ReCAPTCHA script that is not Trusted Types compatible. I see that the URL generated here is passed on to https://github.com/dozoisch/react-async-script, but that should be compatible with a Trusted Types instance, as it doesn't force a stringification before assignment.

Would it be possible to include this as an option, the same way CSP nonces are included? Thank you.